### PR TITLE
Fixed storage init function

### DIFF
--- a/GoogleMusicStorage.py
+++ b/GoogleMusicStorage.py
@@ -9,6 +9,12 @@ class GoogleMusicStorage():
         self.settings = sys.modules["__main__"].settings
         self.path = os.path.join(self.xbmc.translatePath("special://database"), self.settings.getSetting('sqlite_db'))
 
+		# Make sure to initialize database when it does not exist.
+        if ((not os.path.isfile(self.path)) or
+            (not settings.getSetting("firstrun"))):
+            storage.initializeDatabase()
+            settings.setSetting("firstrun", "1")
+
     def getPlaylistSongs(self, playlist_id):
         self._connect()
 

--- a/GoogleMusicStorage.py
+++ b/GoogleMusicStorage.py
@@ -11,9 +11,9 @@ class GoogleMusicStorage():
 
 		# Make sure to initialize database when it does not exist.
         if ((not os.path.isfile(self.path)) or
-            (not settings.getSetting("firstrun"))):
+            (not self.settings.getSetting("firstrun"))):
             self.initializeDatabase()
-            settings.setSetting("firstrun", "1")
+            self.settings.setSetting("firstrun", "1")
 
     def getPlaylistSongs(self, playlist_id):
         self._connect()

--- a/GoogleMusicStorage.py
+++ b/GoogleMusicStorage.py
@@ -12,7 +12,7 @@ class GoogleMusicStorage():
 		# Make sure to initialize database when it does not exist.
         if ((not os.path.isfile(self.path)) or
             (not settings.getSetting("firstrun"))):
-            storage.initializeDatabase()
+            self.initializeDatabase()
             settings.setSetting("firstrun", "1")
 
     def getPlaylistSongs(self, playlist_id):

--- a/default.py
+++ b/default.py
@@ -27,10 +27,6 @@ if (__name__ == "__main__" ):
     import GoogleMusicStorage
     storage = GoogleMusicStorage.GoogleMusicStorage()
 
-    if (not settings.getSetting("firstrun")):
-        storage.initializeDatabase()
-        settings.setSetting("firstrun", "1")
-
     import GoogleMusicNavigation
     navigation = GoogleMusicNavigation.GoogleMusicNavigation()
 


### PR DESCRIPTION
Hi Vially,

When you remove the database using SSH, it is not initialized if the script has already run. You have to clear the cache for this. This fix checks at the init of GoogleStorage which makes going to cache obsolete.

Regards,
Gilles
