### PR TITLE
Update gmusic API Version

### DIFF
--- a/GoogleMusicApi.py
+++ b/GoogleMusicApi.py
@@ -52,7 +52,9 @@ class GoogleMusicApi():
 
     def updatePlaylists(self, playlist_type):
         self.login.login()
-        playlists = self.gmusicapi.get_all_playlist_ids(playlist_type=="auto", playlist_type=="user", always_id_lists=True)
+        playlists = self.gmusicapi.get_all_playlist_ids(auto=True,
+                                                        user=True,
+                                                        always_id_lists=True)
         self.storage.storePlaylists(playlists[playlist_type], playlist_type)
 
     def getSongStreamUrl(self, song_id):

--- a/GoogleMusicNavigation.py
+++ b/GoogleMusicNavigation.py
@@ -12,15 +12,15 @@ ADDON = xbmcaddon.Addon(id='plugin.audio.googlemusic')
 
 class GoogleMusicNavigation():
     def __init__(self):
-        self.xbmc = sys.modules["__main__"].xbmc
-        self.xbmcgui = sys.modules["__main__"].xbmcgui
+        self.xbmc       = sys.modules["__main__"].xbmc
+        self.xbmcgui    = sys.modules["__main__"].xbmcgui
         self.xbmcplugin = sys.modules["__main__"].xbmcplugin
-        self.xbmcvfs = sys.modules["__main__"].xbmcvfs
-
-        self.settings = sys.modules["__main__"].settings
-        self.language = sys.modules["__main__"].language
-        self.dbg = sys.modules["__main__"].dbg
-        self.common = sys.modules["__main__"].common
+        self.xbmcvfs    = sys.modules["__main__"].xbmcvfs
+        
+        self.settings   = sys.modules["__main__"].settings
+        self.language   = sys.modules["__main__"].language
+        self.dbg        = sys.modules["__main__"].dbg
+        self.common     = sys.modules["__main__"].common
 
         self.api = GoogleMusicApi.GoogleMusicApi()
 
@@ -102,7 +102,10 @@ class GoogleMusicNavigation():
 
         try :
                 # Set useragent, sites don't like to interact with scripts
-                headers = { 'User-Agent':'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.8) Gecko/20100723 Ubuntu/10.04 (lucid) Firefox/3.6.8','Accept':'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8','Accept-Language':'en-us,en;q=0.5','Accept-Charset':'ISO-8859-1,utf-8;q=0.7,*;q=0.7'}
+                headers = { 'User-Agent':'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.8) Gecko/20100723 Ubuntu/10.04 (lucid) Firefox/3.6.8',
+                            'Accept':'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                            'Accept-Language':'en-us,en;q=0.5',
+                            'Accept-Charset':'ISO-8859-1,utf-8;q=0.7,*;q=0.7'}
                 req = urllib2.Request(url=url, headers=headers)
                 f = urllib2.urlopen(req)
                 imagedata = f.read()		# Downloads imagedata

--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@
 
 **This plugin is a very early release and uses an [Unofficial-Google-Music-Api](https://github.com/simon-weber/Unofficial-Google-Music-API) so use at your own risk.**
 
-This plugin has been tested with XBMC 11.0 Eden on Linux running Python 2.7.3
+This plugin has been tested with:
+ *  XBMC 11.0 Eden on Linux running Python 2.7.3
+ *  XBMC 12.0 rc3 Frodo on Mac running Python 2.7.3
 
 ##Installation
 
-To install this add-on you must download it from the [Downloads](https://github.com/vially/googlemusic-xbmc/downloads) page and install it using the Add-on Manager from within XBMC by going to:
+To install this add-on you must download it from the
+[Downloads](https://github.com/vially/googlemusic-xbmc/downloads) (or get the
+[current version](https://github.com/vially/googlemusic-xbmc/archive/master.zip)
+and install it using the Add-on Manager from within XBMC by going to:
 
 1. Settings
 2. Add-ons
@@ -47,3 +52,6 @@ Since no checks are being made to verify that the cookie file is still valid, wh
 When this happens you will have to open the add-on settings dialog, go to the Advanced tab and select "Clear cookies".
 
 Hopefully this will be fixed in the next release so this should be just a temporary problem.
+
+### Google Two-Factor Authentication
+Remember if you use two-factor auth with Google you need to get an application specific password.

--- a/addon.xml
+++ b/addon.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.audio.googlemusic"
        name="Google Music"
-       version="0.2.1"
+       version="0.2.2"
        provider-name="Valentin-Costel Hăloiu">
   <requires>
     <import addon="xbmc.python" version="2.0"/>
     <import addon="script.module.parsedom" version="1.0.0"/>
-    <import addon="script.module.gmusicapi" version="2012.05.04"/>
+    <import addon="script.module.gmusicapi" version="2012.11.09"/>
   </requires>
-  <extension point="xbmc.python.pluginsource"
-            library="default.py">
+  <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>audio</provides>
   </extension>
   <extension point="xbmc.addon.metadata">
     <platform>all</platform>
     <summary lang="en">Google Music audio plugin</summary>
-    <description lang="en">Plugin that lets you play music form Google Music.</description>
+    <description lang="en">Plugin that lets you play music from Google Music.</description>
     <disclaimer>Some parts of this addon may not be legal in your country of residence - please check with your local laws before installing.</disclaimer>
   </extension>
 </addon>

--- a/default.py
+++ b/default.py
@@ -1,7 +1,7 @@
 import sys, xbmc, xbmcgui, xbmcplugin, xbmcaddon, xbmcvfs
 
 # plugin constants
-version = "0.2.1"
+version = "0.2.2"
 plugin = "GoogleMusic-" + version
 
 # xbmc hooks


### PR DESCRIPTION
Even though the version of the gmusic api is specified I was getting the
new version. There is a slight change to the api that was crashing the
plugin. I fixed the function call to gmusicapi.get_all_playlist_ids.

Updated the plugin version number to reflect the changed prerequisite.
