### PR TITLE
Fixed issue with playlists not showing all songs with Mobileclient

### DIFF
--- a/GoogleMusicApi.py
+++ b/GoogleMusicApi.py
@@ -60,9 +60,9 @@ class GoogleMusicApi():
             self.main.log("First Song: "+repr(api_songs[0]))
         else:
             if self.login.getDevice():
-                 self.storage.storePlaylistSongs(self.gmusicapi.get_all_user_playlist_contents())
+                self.storage.storePlaylistSongs(self.gmusicapi.get_all_user_playlist_contents())
             else:
-                 api_songs = self.gmusicapi.get_playlist_songs(playlist_id)
+                api_songs = self.gmusicapi.get_playlist_songs(playlist_id)
 
         if api_songs:
             self.storage.storeApiSongs(api_songs, playlist_id)
@@ -87,7 +87,7 @@ class GoogleMusicApi():
         else:
             streams = self.gmusicapi.get_stream_urls(song_id)
             if len(streams) > 1:
-                xbmc.executebuiltin("XBMC.Notification("+plugin+",'All Access track not playable')")
+                self.main.xbmc.executebuiltin("XBMC.Notification("+plugin+",'All Access track not playable')")
                 raise Exception('All Access track not playable, no mobile device found in account!')
             stream_url = streams[0]
 

--- a/GoogleMusicPlaySong.py
+++ b/GoogleMusicPlaySong.py
@@ -17,7 +17,7 @@ class GoogleMusicPlaySong():
         if song:
             if self.prefetch=="false" or not song[24] or int(self.main.parameters_string_to_dict(song[24]).get('expire'))  < time.time():
                  self.main.log("Prefetch disabled or URL invalid or expired :")
-                 url = self.__getSongStreamUrl(song_id)
+                 url = self.__getSongStreamUrl(song[-1])
             else:
                  url = song[24]
 


### PR DESCRIPTION
I got so excited when I found this plugin that when it didn't work for me today I spent my whole day trying to fix it.

It looks like, when updating playlists while using the Mobileclient, it wasn't storing any of the songs it found in the 'all_music' table. Additionally, it was storing the trackId in the 'playlists_songs' table, instead of the normal 'id', causing issues with joining records. Finally, the table in 'all_music' didn't have a column that covered 'trackId'.

When trying to populate the list of tracks, it does a JOIN between 'playlists_songs' and 'songs', but first these records weren't making it into the table, and then when the table didn't have a column for that key. It would only work if you first updated "all_tracks", and even then "all_tracks" is only items added to your library, so any All Access songs you added to a playlist but not your library wouldn't show up.

So now instead I add the normal 'id' to the 'playlists_songs' table, and just store the trackId in the 'songs' table.

When trying to play a song using the Mobileclient, it didn't seem to like the normal 'id' that was being passed in, and came came back with "Not Found" errors. So now whatever's in the 'trackId' column is what gets fed into "__getSongStreamUrl". The 'trackId' column contains a 'trackId' attribute whenever it's found. When not, it falls back on the plain 'id'.

Works for me smoothly so far...but admittedly I haven't been testing long. And I think it's backwards compatible for people not using the Mobileclient, but I haven't been able to test that myself.
