### PR TITLE
fix TypeError: createFolder() takes at least 3 arguments

### DIFF
--- a/GoogleMusicNavigation.py
+++ b/GoogleMusicNavigation.py
@@ -522,7 +522,7 @@ class GoogleMusicNavigation():
             if result['videos']:
                 listItems.append(self.createFolder('[COLOR orange]*** Youtube ***[/COLOR]',{'path':'none'}))
                 for video in result['videos']:
-                    listItems.append(self.createFolder(video['title']),{'action':'play_yt','title':video['title']})
+                    listItems.append(self.createFolder(video['title'],{'action':'play_yt','title':video['title']}))
 
         elif 'artistid' in query:
             result = self.api.getArtistInfo(query['artistid'], True, 20, 0)


### PR DESCRIPTION
Not sure what exactly my change does, but it works and looks right! Merge if you'd like :-)

ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.TypeError'>
                                            Error Contents: createFolder() takes at least 3 arguments (2 given)
                                            Traceback (most recent call last):
                                              File "/home/bkanuka/.kodi/addons/plugin.audio.googlemusic.exp/default.py", line 59, in <module>
                                                GoogleMusicNavigation.GoogleMusicNavigation().listMenu(params)
                                              File "/home/bkanuka/.kodi/addons/plugin.audio.googlemusic.exp/GoogleMusicNavigation.py", line 115, in listMenu
                                                listItems = self.getSearch(keyboard.getText())
                                              File "/home/bkanuka/.kodi/addons/plugin.audio.googlemusic.exp/GoogleMusicNavigation.py", line 525, in getSearch
                                                listItems.append(self.createFolder(video['title']),{'action':'play_yt','title':video['title']})
                                            TypeError: createFolder() takes at least 3 arguments (2 given)
                                            -->End of Python script error report<--
