### PR TITLE
Update GoogleMusicApi.py so prior search works

### DIFF
--- a/GoogleMusicApi.py
+++ b/GoogleMusicApi.py
@@ -114,6 +114,8 @@ class GoogleMusicApi():
         return storage.getCriteria(criteria,artist)
 
     def getSearch(self, query, max_results=10):
+        import urllib	
+        query = urllib.unquote(query).decode('utf8')
         utils.log("API getsearch: "+query)
         result = storage.getSearch(query, max_results)
         #result = {'tracks':[],'albums':[],'artists':[]}


### PR DESCRIPTION
Selecting cached previous searches was leaving chars such as %20 encoded, two lines of code added so that it correctly now re-searches any prior search that included a space